### PR TITLE
added combo box to allow preview of style (#10)

### DIFF
--- a/latest/dimensions.inx
+++ b/latest/dimensions.inx
@@ -39,7 +39,7 @@
                                 <option value="ft">ft</option>
                                 <option value="px">pixel</option>
                             </param>
-                            <param name="LINscaleDim" type="float" min="0.01" max="100" precision="2" gui-text="Sale factor¹:">1.0</param>
+                            <param name="LINscaleDim" type="float" min="0.01" max="10000" precision="2" gui-text="Sale factor¹:">1.0</param>
                             <param name="LINprecision" type="int" min="0" max="5" gui-text="Digits of precision:">0</param>
                             <param name="LINunitSymbol" type="bool" gui-text="Add unit symbol">false</param>
                         </page>

--- a/latest/dimensions.inx
+++ b/latest/dimensions.inx
@@ -49,6 +49,8 @@
                     </param>
                 </vbox>
             </hbox>
+            <spacer size="expand"/>
+            <label>¹ default: 1.0.</label>
         </page>
         <page name="Angular" appearance="minimal" gui-text="Angular">
             <hbox>
@@ -94,6 +96,8 @@
         <page name="Arrow" appearance="minimal" gui-text="Arrows">
             <param name="anotationScale" type="float" min="0.01" max="100" precision="2" gui-text="Scale factor¹:">1.0</param>
             <param name="anotationText" type="string" appearance="multiline" gui-text="Contents:">value</param>
+            <spacer size="expand"/>
+            <label>¹ default: 1.0.</label>
         </page>
         <page name="Config" appearance="minimal" gui-text="Configuration">
             <param name="useLatex" type="bool" gui-text="Use LaTeX">false</param>
@@ -170,7 +174,11 @@
             <label appearance="url">https://github.com/fsmMLK/inkscapeDimensions</label>
         </page>
     </param>
-    <label>¹ default: 1.0.</label>
+    <param name="dimensionType" type="optiongroup" appearance="combo" gui-text="Type:">
+        <option value="Linear">Linear</option>
+        <option value="Angular">Angular</option>
+        <option value="Arrow">Arrow</option>
+    </param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>

--- a/latest/dimensions.py
+++ b/latest/dimensions.py
@@ -138,6 +138,8 @@ class Dimensions(inkBase.inkscapeMadeEasy):
         self.arg_parser.add_argument("--lineColor", type=str, dest="lineColorOption", default='black')
         self.arg_parser.add_argument("--colorPickerLine", type=str, dest="colorPickerLine", default='0')
 
+        self.arg_parser.add_argument("--dimensionType", type=str, dest="dimensionType", default='Linear')     
+
     def effect(self):
 
         so = self.options
@@ -224,7 +226,7 @@ class Dimensions(inkBase.inkscapeMadeEasy):
         self.annotationLineStyle = inkDraw.lineStyle.set(lineWidth=self.lineWidth * so.anotationScale, lineColor=self.lineColor,
                                                          markerStart=arrowStart)
 
-        if so.tab == 'Linear':
+        if self.options.dimensionType == 'Linear':
             # get points of selected object
             for id, element in self.svg.selected.items():
                 [P1, P2] = self.getPointsLinDim(element, so.LINdirection)
@@ -239,7 +241,7 @@ class Dimensions(inkBase.inkscapeMadeEasy):
                 if so.removeAuxLine:
                     self.removeElement(element)
 
-        if so.tab == 'Angular':
+        if self.options.dimensionType == 'Angular':
             # get points of selected object
             for id, element in self.svg.selected.items():
                 self.drawAngDim(root_layer, element, label='Dim', invertAngle=so.ANGinvertAngle, textType=so.AngContents_subtab,
@@ -249,7 +251,7 @@ class Dimensions(inkBase.inkscapeMadeEasy):
                 if so.removeAuxLine:
                     self.removeElement(element)
 
-        if so.tab == 'Arrow':
+        if self.options.dimensionType == 'Arrow':
             for id, element in self.svg.selected.items():
                 self.drawAnnotationArrow(root_layer, element, contents=so.anotationText, scale=so.anotationScale)
                 self.removeElement(element)


### PR DESCRIPTION
I added a combo box to select the type of dimensioning.
This enables to see the changes made in the config or style tab in the preview.
Resolves https://github.com/fsmMLK/inkscapeDimensions/issues/10
![Screenshot_2021-04-24_10-08-23](https://user-images.githubusercontent.com/67957916/115952517-adc90d80-a4e6-11eb-9f09-e5e8a7ab65f8.png)